### PR TITLE
Fix wrong setup step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Then add the following to your shell config at the end:
 
 ```
 export PATH="$HOME/.phantomenv/bin:$PATH"
-eval "(phantomenv init -)"
+eval "$(phantomenv init -)"
 ```
 
 ## Usage


### PR DESCRIPTION
We were having a problem when setting up phantom env in one of our machines. The problem was related to the put `eval "(phantomenv init -)"` in bash profile, as said in the README.

The problem was that `eval "(phantomenv init -)"` is different from `eval "$(phantomenv init -)"` with the $ sign. The $ sign is needed for a subshell returning a string, so that it can be later evaluated.

This PR adds the $ sign so that the commands output can be evaluated.

Side-note, the $ sign is already being used in https://github.com/wfarr/phantomenv/blob/master/libexec/phantomenv-init#L3

obs.: forgive me if I said something dumb, I'm a noob in bash script.