### PR TITLE
Add the arch info back to the alt download URL.

### DIFF
--- a/libexec/phantomenv-install
+++ b/libexec/phantomenv-install
@@ -35,7 +35,7 @@ arch="$(uname -m)"
 
 # URL to download from
 download="https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${version}-${platform}.zip"
-alt_download="https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${version}-${platform}.tar.bz2"
+alt_download="https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${version}-${platform}-${arch}.tar.bz2"
 
 # Can't get too clever here
 set +e


### PR DESCRIPTION
This was mistakenly removed by #3, and we need it back to
use phantomenv on Linux.
